### PR TITLE
Remove api switch case if api is NULL and return error.

### DIFF
--- a/fs/fs.c
+++ b/fs/fs.c
@@ -39,27 +39,26 @@ void pi_fs_conf_init(struct pi_fs_conf *conf)
 }
 
 
-extern pi_fs_api_t pi_lfs_api;
-
-
-
 int32_t pi_fs_mount(struct pi_device *device)
 {
   struct pi_fs_conf *conf = (struct pi_fs_conf *)device->config;
   pi_fs_api_t *api = conf->api;
 
-  switch (conf->type)
+  if (api == NULL)
   {
-    case PI_FS_READ_ONLY:
+    switch (conf->type)
+    {
+      case PI_FS_READ_ONLY:
         api = &__pi_read_fs_api;
         break;
 
-  case PI_FS_HOST:
-      api = &__pi_host_fs_api;
-      break;
+      case PI_FS_HOST:
+        api = &__pi_host_fs_api;
+        break;
 
-  default:
-      return 1;
+      default:
+        return -1;
+    }
   }
 
   device->api = (struct pi_device_api *)api;

--- a/fs/fs.c
+++ b/fs/fs.c
@@ -47,26 +47,10 @@ int32_t pi_fs_mount(struct pi_device *device)
 {
   struct pi_fs_conf *conf = (struct pi_fs_conf *)device->config;
   pi_fs_api_t *api = conf->api;
-  
+
   if (api == NULL)
   {
-    switch (conf->type)
-    {
-      case PI_FS_READ_ONLY:
-        api = &__pi_read_fs_api;
-        break;
-
-      case PI_FS_LFS:
-        api = &pi_lfs_api;
-        break;
-
-      case PI_FS_HOST:
-        api = &__pi_host_fs_api;
-        break;
-
-      default:
-        return -1;
-    }
+      return -1;
   }
 
   device->api = (struct pi_device_api *)api;

--- a/fs/fs.c
+++ b/fs/fs.c
@@ -48,9 +48,18 @@ int32_t pi_fs_mount(struct pi_device *device)
   struct pi_fs_conf *conf = (struct pi_fs_conf *)device->config;
   pi_fs_api_t *api = conf->api;
 
-  if (api == NULL)
+  switch (conf->type)
   {
-      return -1;
+    case PI_FS_READ_ONLY:
+        api = &__pi_read_fs_api;
+        break;
+
+  case PI_FS_HOST:
+      api = &__pi_host_fs_api;
+      break;
+
+  default:
+      return 1;
   }
 
   device->api = (struct pi_device_api *)api;

--- a/fs/host_fs/host_fs.c
+++ b/fs/host_fs/host_fs.c
@@ -156,5 +156,6 @@ pi_fs_api_t __pi_host_fs_api = {
 void pi_hostfs_conf_init(struct pi_hostfs_conf *conf)
 {
     pi_fs_conf_init(&conf->fs);
+    conf->fs.type = PI_FS_HOST;
     conf->fs.api = &__pi_host_fs_api;
 }

--- a/fs/lfs/pi_lfs.c
+++ b/fs/lfs/pi_lfs.c
@@ -450,5 +450,6 @@ lfs_t *pi_lfs_get_native_lfs(pi_device_t *device)
 void pi_lfs_conf_init(struct pi_lfs_conf *conf)
 {
     pi_fs_conf_init(&conf->fs);
+    conf->fs.type = PI_FS_LFS;
     conf->fs.api = &pi_lfs_api;
 }

--- a/fs/read_fs/read_fs.c
+++ b/fs/read_fs/read_fs.c
@@ -662,5 +662,6 @@ pi_fs_api_t __pi_read_fs_api = {
 void pi_readfs_conf_init(struct pi_readfs_conf *conf)
 {
     pi_fs_conf_init(&conf->fs);
+    conf->fs.type = PI_FS_READ_ONLY;
     conf->fs.api = &__pi_read_fs_api;
 }

--- a/include/bsp/fs.h
+++ b/include/bsp/fs.h
@@ -558,6 +558,7 @@ struct __pi_fs_api_t {
 
 extern pi_fs_api_t __pi_read_fs_api;
 extern pi_fs_api_t __pi_host_fs_api;
+extern pi_fs_api_t pi_lfs_api;
 
 typedef struct pi_fs_file_s {
   struct pi_device *fs;


### PR DESCRIPTION
Remove switch case in pi_fs_mount in case api is NULL, and return error.
This piece of code pulls unnecessary code. Api should be set in conf init, if it is not, then return error.