### PR TITLE
Fix read_fs when using cluster to read

### DIFF
--- a/fs/fs.c
+++ b/fs/fs.c
@@ -171,7 +171,9 @@ void __pi_cl_fs_req(void *_req)
     }
     else
     {
-        req->result = pi_fs_read_async(req->file, req->buffer, req->size, pi_task_callback(&req->task, __pi_cl_fs_req_done, (void *)req));
+        pi_task_callback(&req->task, __pi_cl_fs_req_done, (void *)req);
+        req->result = pi_fs_read_async(req->file, req->buffer, req->size, NULL);
+        pi_task_push(&req->task);
     }
 }
 


### PR DESCRIPTION
Send a NULL event to `pi_fs_read_async()` when using read_fs with cluster. This is to avoid a cluster unblock too early with preemptive systems.
Otherwise `req->result` is never set, cluster task is unblocked and task is cleared before return value is set.